### PR TITLE
fix: scope record lookup to table and project

### DIFF
--- a/src/main/java/rinsanom/com/springtwodatasoure/service/impl/TableServiceImpl.java
+++ b/src/main/java/rinsanom/com/springtwodatasoure/service/impl/TableServiceImpl.java
@@ -388,10 +388,10 @@ public class TableServiceImpl implements TableService {
             }
 
             // Get the main record by searching in the specific table and project
-            Optional<TableData> tableDataOpt = tableDataRepository.findById(id);
-            if (tableDataOpt.isEmpty() ||
-                !tableDataOpt.get().getSchemaName().equals(schemaName) ||
-                !tableDataOpt.get().getProjectId().equals(projectId)) {
+            Optional<TableData> tableDataOpt = tableDataRepository.findByIdAndSchemaNameAndProjectId(
+                id, schemaName, projectId
+            );
+            if (tableDataOpt.isEmpty()) {
                 return null;
             }
 


### PR DESCRIPTION
## Summary
- ensure relational record lookup uses table and project scoping to avoid cross-table mismatches

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.2.0, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1b4f0118832ca5c71ef27b41335e